### PR TITLE
Renamed FoodRequest form

### DIFF
--- a/apps/ui/components/requests/FoodRequestForm.vue
+++ b/apps/ui/components/requests/FoodRequestForm.vue
@@ -10,12 +10,12 @@
 
 
 <script setup lang="ts">
-import type { FoodDeliveryFormState } from '@/types/index';
+import type { FoodRequestFormState } from '@/types/index';
 
 const props = defineProps<{
   // validate: (state: any) => { path: string; message: string }[];
   // onSubmit: (state: any) => void;
-  state: FoodDeliveryFormState;
+  state: FoodRequestFormState;
   googleMapsIsReady?: boolean;
 }>();
 
@@ -32,7 +32,7 @@ const vueform = ref<any>(null);
  *
  **/
 onMounted(() => {
-  console.log("FoodDeliveryFormState has been mounted");
+  console.log("FoodRequestFormState has been mounted");
 
   const state = props.state;
   console.log("state", state);

--- a/apps/ui/pages/requests/new.vue
+++ b/apps/ui/pages/requests/new.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { FoodDeliveryFormState } from '@/types/index';
+import type { FoodRequestFormState } from '@/types/index';
 
 definePageMeta({
   layout: 'dashboard',
@@ -31,7 +31,7 @@ import { Loader } from "@googlemaps/js-api-loader";
 const googleAPIKey = 'AIzaSyC_UvqrTnimc1Pc7LDYCqdqUiGMMUgMCWg'
 const googleMapsIsReady = ref(false)
 
-const state: Ref<FoodDeliveryFormState | null> = ref(null)
+const state: Ref<FoodRequestFormState | null> = ref(null)
 
 const loader = new Loader({
   apiKey: googleAPIKey,
@@ -128,7 +128,7 @@ onMounted(() => {
 
       <UDashboardPanelContent class="pb-12 pr-16 mr-16">
 
-        <RequestsFoodDeliveryForm v-if="state" :state="state" :googleMapsIsReady="googleMapsIsReady" />
+        <RequestsFoodRequestForm v-if="state" :state="state" :googleMapsIsReady="googleMapsIsReady" />
 
       </UDashboardPanelContent>
 

--- a/apps/ui/types/index.d.ts
+++ b/apps/ui/types/index.d.ts
@@ -31,7 +31,7 @@ export interface SessionData {
 }
 
 
-export interface FoodDeliveryFormState {
+export interface FoodRequestFormState {
   // Define your state properties here
   delivery_address: {
       branch_location: string;


### PR DESCRIPTION
This pull request renames the `FoodDeliveryFormState` interface to `FoodRequestFormState` to better reflect its purpose.