### PR TITLE
[#138] Fix request history visibility and add status field

### DIFF
--- a/apps/api/afbcore/serializers/food_request_serializer.py
+++ b/apps/api/afbcore/serializers/food_request_serializer.py
@@ -29,6 +29,7 @@ class FoodRequestCreateSerializer(serializers.ModelSerializer):
             "date_requested",
             "safe_drop_agree",
             "safe_drop_instructions",
+            "status",
         ]
         read_only_fields = [
             "id",
@@ -39,6 +40,7 @@ class FoodRequestCreateSerializer(serializers.ModelSerializer):
             # prevent the UUID value from making it into
             # the database -- leading to a NULL error
             # since a request must have a user.
+            "status",
         ]
 
 
@@ -71,6 +73,7 @@ class FoodRequestUpdateSerializer(serializers.ModelSerializer):
             "date_requested",
             "safe_drop_agree",
             "safe_drop_instructions",
+            "status",
         ]
         read_only_fields = [
             "id",
@@ -80,4 +83,5 @@ class FoodRequestUpdateSerializer(serializers.ModelSerializer):
             "address_canadapost_id",
             "address_google_place_id",
             "pet_details",
+            "status",
         ]

--- a/apps/ui/components/requests/FoodRequestForm.vue
+++ b/apps/ui/components/requests/FoodRequestForm.vue
@@ -61,12 +61,13 @@ const submitFoodRequest = async (form$: any, FormData: any) => {
 };
 
 /**
- *  WARNING! ATTENTION! ACHTUNG! ATENCIÓN!
+ * WARNING! ATTENTION! ACHTUNG! ATENCIÓN! 注意! ВНИМАНИЕ! توجه!
  *
  * Never define const state = ref() outside of <script setup> or setup() function.
  * Such state will be shared across all users visiting your website and
  * can lead to memory leaks!
  * Instead use const useX = () => useState('x')
+ *
  *    -- https://nuxt.com/docs/getting-started/state-management#best-practices
  *
  **/

--- a/apps/ui/components/requests/List.vue
+++ b/apps/ui/components/requests/List.vue
@@ -45,7 +45,7 @@ onMounted(() => {
             <th scope="col" class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white sm:table-cell">Contact</th>
             <th scope="col" class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white sm:table-cell">Address</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white sm:table-cell sm:pl-0 ">Contents</th>
-            <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-0"><span class="sr-only">Link</span></th>
+            <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-0"><span class="sr-only">View</span></th>
           </tr>
         </thead>
         <tbody class="divide-y divide-gray-200 bg-white dark:bg-gray-900 dark:divide-gray-500">

--- a/apps/ui/components/requests/List.vue
+++ b/apps/ui/components/requests/List.vue
@@ -9,9 +9,16 @@ const props = defineProps<{
   cta?: Boolean
 }>()
 
-const requests = ref(props.requests || [])
-const hasOpenRequests = computed(() => requests.value.some(request => request.status !== 'delivered'))
-// A list of all the users in your account including their name, title, email and role.
+const visibleRequests = ref(props.requests || [])
+const hasOpenRequests = ref(false)
+
+onMounted(() => {
+  console.log('requests', visibleRequests.value)
+  let computedValue = computed(() => visibleRequests.value.some(request => request.status !== 'delivered'))
+  hasOpenRequests.value = computedValue.value
+})
+
+
 </script>
 
 <template>
@@ -29,23 +36,7 @@ const hasOpenRequests = computed(() => requests.value.some(request => request.st
         </a>
       </div>
     </div>
-    <!-- {
-  "address_text": "1201 Kingsway, Med Hat",
-  "address_google_place_id": null,
-  "address_canadapost_id": null,
-  "address_latitude": null,
-  "address_longitude": null,
-  "address_buildingtype": "NOT_SPECIFIED",
-  "address_details": {},
-  "contact_phone": "+12507772171",
-  "contact_email": "",
-  "contact_name": "Pearl",
-  "method_of_contact": "Email",
-  "pet_details": {},
-  "confirm_correct": true,
-  "accept_terms": true,
-  "date_requested": "2024-04-06"
-} -->
+
     <div class="-mx-4 mt-8 sm:-mx-0">
       <table class="min divide-y divide-gray-300 dark:divide-gray-300">
         <thead>

--- a/apps/ui/components/requests/List.vue
+++ b/apps/ui/components/requests/List.vue
@@ -9,6 +9,8 @@ const props = defineProps<{
   cta?: Boolean
 }>()
 
+const requests = ref(props.requests || [])
+const hasOpenRequests = computed(() => requests.value.some(request => request.status !== 'delivered'))
 // A list of all the users in your account including their name, title, email and role.
 </script>
 
@@ -21,7 +23,7 @@ const props = defineProps<{
         <p class="mt-2 text-sm text-gray-700 dark:text-gray-200">{{ description }}</p>
       </div>
       <div class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
-        <a v-if="cta" type="button" href="/requests/new"
+        <a v-if="cta && !hasOpenRequests" type="button" href="/requests/new"
                 class="block rounded-md bg-primary px-3 py-2 text-center text-sm font-semibold text-white dark:text-black shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 ">
                 Request Pet Food
         </a>
@@ -48,15 +50,19 @@ const props = defineProps<{
       <table class="min divide-y divide-gray-300 dark:divide-gray-300">
         <thead>
           <tr>
-            <th scope="col" class="hidden py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 dark:text-white lg:table-cell sm:pl-0 ">Date</th>
-            <th scope="col" class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white lg:table-cell">Contact</th>
-            <th scope="col" class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white lg:table-cell">Address</th>
+            <th scope="col" class="hidden py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 dark:text-white sm:table-cell sm:pl-0 ">Date</th>
+            <th scope="col" class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white sm:table-cell">Contact</th>
+            <th scope="col" class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white sm:table-cell">Address</th>
             <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white sm:table-cell sm:pl-0 ">Contents</th>
-            <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-0"><span class="sr-only">View</span></th>
+            <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-0"><span class="sr-only">Link</span></th>
           </tr>
         </thead>
-        <tbody class="divide-y divide-gray-200 bg-white dark:bg-slate-900 dark:divide-gray-500">
-          <tr v-for="request in requests" :key="request.id">
+        <tbody class="divide-y divide-gray-200 bg-white dark:bg-gray-900 dark:divide-gray-500">
+          <tr
+            v-for="(request, index) in requests"
+            :key="request.id"
+            :class="(index === 0) ? 'bg-slate-100 dark:bg-slate-800': ''"
+            >
             <td class="max-w-sm w-full py-4 pl-4 pr-3 text-sm font-medium text-gray-900 dark:text-white sm:w-auto sm:max-w-none sm:pl-0">
               {{ request.date_requested }}
               <dl class="font-normal lg:hidden">
@@ -68,11 +74,11 @@ const props = defineProps<{
                 <dd class="mt-1 truncate text-gray-500 dark:text-gray-200">{{ request.address_text }}</dd>
               </dl>
             </td>
-            <td class="max-w-xs hidden px-3 py-4 text-sm text-gray-500 dark:text-gray-200 lg:table-cell">{{ request.contact_name }}</td>
+            <td  class="max-w-xs hidden px-3 py-4 text-sm text-gray-500 dark:text-gray-200 lg:table-cell">{{ request.contact_name }}</td>
             <td class="max-w-xs hidden px-3 py-4 text-sm text-gray-500 dark:text-gray-200 lg:table-cell">{{ request.address_text }}</td>
             <td class="max-w-xs hidden px-3 py-4 text-sm text-gray-500 dark:text-gray-200 lg:table-cell">{{ request.pet_details?.pets_blob }}</td>
             <td class="py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-0">
-            <a :href="`/requests/${request.id}/details`" class="text-indigo-600 hover:text-indigo-900 dark:text-blue-400">View<span class="sr-only">, {{ request.name
+            <a :href="`/requests/${request.id}/details`" class="text-indigo-600 hover:text-indigo-900 dark:text-blue-400">{{ request.status }}<span class="sr-only">, {{ request.name
                   }}</span></a>
             </td>
           </tr>

--- a/apps/ui/pages/dashboard/index.vue
+++ b/apps/ui/pages/dashboard/index.vue
@@ -15,12 +15,21 @@ definePageMeta({
   layout: 'dashboard',
 })
 
+
+/**
+ * Retrieves the authentication status, data, and token using the useAuth() function.
+ *
+ * @returns {{
+ *   status: string,
+ *   data: any,
+ *   token: string
+ * }} The authentication status, data, and token.
+ */
 const {
   status: authStatus,
   data: authData,
   token: authToken,
 } = useAuth();
-
 
 const requests = ref([]);
 

--- a/apps/ui/pages/requests/index.vue
+++ b/apps/ui/pages/requests/index.vue
@@ -57,6 +57,7 @@ onMounted(() => {
           :cta="true"
           :requests="requests"
         />
+
       </UDashboardPanelContent>
     </UDashboardPanel>
   </UDashboardPage>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ dependencies:
     specifier: ^3.2.5
     version: 3.2.5
   vue:
-    specifier: ^3.4.21
+    specifier: ^3.4.0
     version: 3.4.21(typescript@5.4.5)
   vue-router:
     specifier: ^4.3.0


### PR DESCRIPTION
This pull request fixes the visibility of the request history and adds a new 'status' field to track the status of requests. It improves the requests list component to pre-filter requests client-side, avoiding unnecessary server round trips. Additionally, it updates the request serializers and components to surface the new 'status' field. This PR addresses issue #138.